### PR TITLE
Allow multiple returns, or returns inside of if else blocks

### DIFF
--- a/packages/eslint-config-bletchley/rules/hut4.js
+++ b/packages/eslint-config-bletchley/rules/hut4.js
@@ -1,4 +1,5 @@
 module.exports = {
   'rules': {
+    'no-else-return': 0
   }
 };


### PR DESCRIPTION
Make it legal to do 
`if someBool
  return "Something"
else
  return "Something else"
end
`
