### PR TITLE
Bletchley Wide Config change: only warn on double quotes, allow returns in If statements

### DIFF
--- a/packages/eslint-config-bletchley/rules/best-practices.js
+++ b/packages/eslint-config-bletchley/rules/best-practices.js
@@ -27,7 +27,7 @@ module.exports = {
     // disallow division operators explicitly at beginning of regular expression
     'no-div-regex': 0,
     // disallow else after a return in an if
-    'no-else-return': 2,
+    'no-else-return': 0,
     // disallow use of labels for anything other then loops and switches
     'no-empty-label': 2,
     // disallow comparisons to null without a type-checking operator

--- a/packages/eslint-config-bletchley/rules/hut4.js
+++ b/packages/eslint-config-bletchley/rules/hut4.js
@@ -1,5 +1,6 @@
 module.exports = {
   'rules': {
-    'no-else-return': 0
+    'no-else-return': 0,
+    'quotes': [1, 'single', 'avoid-escape']
   }
 };

--- a/packages/eslint-config-bletchley/rules/style.js
+++ b/packages/eslint-config-bletchley/rules/style.js
@@ -88,7 +88,7 @@ module.exports = {
     // http://eslint.org/docs/rules/quote-props.html
     'quote-props': [2, 'as-needed', { 'keywords': false, 'unnecessary': true, 'numbers': false }],
     // specify whether double or single quotes should be used
-    'quotes': [2, 'single', 'avoid-escape'],
+    'quotes': [1, 'single', 'avoid-escape'],
     // require identifiers to match the provided regular expression
     'id-match': 0,
     // enforce spacing before and after semicolons


### PR DESCRIPTION
As per the discussion in scrum: changing the quotes rule to a warning only
Single quotes are good in general and should be used for all cases once you are committing or merging. But maybe not a big deal for totally exiting all code and holding up the development process.

Moved the No return in If's statement to bletchely wide rules
